### PR TITLE
update get payload function and README.md for scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Proxy server that allows you to track pageview events via google analytics. It u
 | Key  | Description                                                   | Example                   | Required |
 | ---- | ------------------------------------------------------------- | ------------------------- | -------- |
 | tid  | Google Analytics tracking ID. GA4 IDs are not supported. [#7](https://github.com/mskims/notion-ga/issues/7)  | UA-99123456-1             | Y        |
-| host | Specifies the hostname. It doesn't matter the specified hostname exists or not. It only appears on your GA dashboard.         | mskim.me                  | Y        |
-| Page | The path portion of the page URL. Should begin with `/`       | /careers/product-designer | Y        |
+| dh | Specifies the hostname. It doesn't matter the specified hostname exists or not. It only appears on your GA dashboard.         | mskim.me                  | Optional        |
+| dp | The path portion of the page URL. Should begin with `/`       | /careers/product-designer | Optional        |
+| dt | The page title | career | Optional        |
 
 ### Example URLs
 

--- a/src/collect.js
+++ b/src/collect.js
@@ -34,11 +34,11 @@ app.get("*", (req, res) => {
 
 const getPayload = req => ({
   v: 1,
-  tid: req.query.tid,
   cid: req.session.id,
   t: "pageview",
-  dh: req.query.host,
-  dp: req.query.page
+  dh: "default.host",
+  dp: "/default/page",
+  ...req.query
 });
 
 const exit = res =>


### PR DESCRIPTION
On page tracking there is more options like dt

```
v=1              // Version.
&tid=UA-XXXXX-Y  // Tracking ID / Property ID.
&cid=555         // Anonymous Client ID.

&t=pageview      // Pageview hit type.
&dh=mydemo.com   // Document hostname.
&dp=/home        // Page.
&dt=homepage     // Title.
```

This repo only handle about tid, dh and dp. 

So i update dh, dp property has default values. 

and update getPayload fucntion.

This let users decide what to wanna change putting parameters same as one required from google. 

